### PR TITLE
Extend center line transformations

### DIFF
--- a/app/process/bikelanes/bikelanesNew.lua
+++ b/app/process/bikelanes/bikelanesNew.lua
@@ -159,7 +159,7 @@ end
 -- Handle "baulich abgesetzte Radwege" ("Protected Bike Lane")
 -- This part relies heavly on the `is_sidepath` tagging.
 local function cyclewayOnHighway(tags)
-  local result = result or (tags.cycleway == "track" or tags.cycleway == "opposite_track")
+  local result = (tags.cycleway == "track" or tags.cycleway == "opposite_track")
   -- Case: Cycleway identified via "lane"-tagging, which means it is part of the highway.
   --    https://wiki.openstreetmap.org/wiki/DE:Tag:cycleway%3Dlane
   --    https://wiki.openstreetmap.org/wiki/DE:Tag:cycleway%3Dopposite_lane

--- a/app/process/bikelanes/bikelanesNew.lua
+++ b/app/process/bikelanes/bikelanesNew.lua
@@ -339,7 +339,7 @@ function osm2pgsql.process_way(object)
       ["sidewalk:left:bicycle"] = { 1 },
       ["sidewalk:right:bicycle"] = { -1 },
       ["sidewalk:both:bicycle"] = { -1, 1 },
-      ["sidewalk:both"] = { -1, 1 },
+      ["sidewalk:bicycle"] = { -1, 1 },
     },
   }
   local cyclewayTransformer = {

--- a/app/process/bikelanes/bikelanesNew.lua
+++ b/app/process/bikelanes/bikelanesNew.lua
@@ -339,6 +339,7 @@ function osm2pgsql.process_way(object)
       ["sidewalk:left:bicycle"] = { 1 },
       ["sidewalk:right:bicycle"] = { -1 },
       ["sidewalk:both:bicycle"] = { -1, 1 },
+      ["sidewalk:both"] = { -1, 1 },
     },
   }
   local cyclewayTransformer = {
@@ -348,6 +349,7 @@ function osm2pgsql.process_way(object)
       ["cycleway:left"] = { 1 },
       ["cycleway:right"] = { -1 },
       ["cycleway:both"] = { -1, 1 },
+      ["cycleway"] = { -1, 1 },
     },
   }
   local transformations = { footwayTransformer, cyclewayTransformer }


### PR DESCRIPTION
The center line transformations are extended s.t. the tags `cycleway` and `bicycle` are treated the same way as `cycleway:both` and `bicycle:both` respectively.

Related to: https://github.com/FixMyBerlin/private-issues/issues/217#issuecomment-1333939928