### PR TITLE
bikelancesNew: Try (and fail) to fix sql geometry missmatch

### DIFF
--- a/app/process/bikelanes/bikelanesNew.lua
+++ b/app/process/bikelanes/bikelanesNew.lua
@@ -37,7 +37,7 @@ local translateTable = osm2pgsql.define_table({
   ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
   columns = {
     { column = 'tags', type = 'jsonb' },
-    { column = 'geom', type = 'linestring' },
+    { column = 'geom', type = 'multilinestring' },
     { column = 'offset', type = 'real' }
   }
 })
@@ -314,7 +314,7 @@ function osm2pgsql.process_way(object)
     -- in future versions we should do this as a concationation of the tables(sql)
     translateTable:insert({
       tags = object.tags,
-      geom = object:as_linestring(),
+      geom = object:as_multilinestring(),
       offset = 0
     })
     return
@@ -371,7 +371,7 @@ function osm2pgsql.process_way(object)
             normalizeTags(object)
             translateTable:insert({
               tags = object.tags,
-              geom = object:as_linestring(),
+              geom = object:as_multilinestring(),
               offset = sign * offset
             })
           end


### PR DESCRIPTION
Error message is
```
tarmac       | psql:./process/bikelanes/bikelanesCenterline.sql:18: ERROR:  Geometry type (LineString) does not match column type (MultiLineString)
```

@rush42 can you take a look. Did not investigate if this is something new due to recent changes or not. My pdf file is old, so should not be caused by new data.

FYI I looked up the possible types at https://github.com/openstreetmap/osm2pgsql/discussions/1844 (or asked to document them more clearly).