### PR TITLE
Refactor/centerline

### DIFF
--- a/app/process/bikelanes/bikelanesCenterline.sql
+++ b/app/process/bikelanes/bikelanesCenterline.sql
@@ -8,6 +8,10 @@ UPDATE "bikelanesCenterlineNew"
   SET geom=ST_Reverse(ST_Transform(ST_OffsetCurve(ST_Transform(geom, 25833), "offset", 'quad_segs=4 join=round'), 3857))
   WHERE ST_IsSimple(geom) and not ST_IsClosed(geom) and "offset"!=0;
 
+UPDATE "bikelanesCenterlineNew"
+  SET osm_id=osm_id*SIGN("offset");
+
+
 INSERT INTO "bikelanesNew"
   SELECT osm_type, osm_id, tags, geom
   FROM "bikelanesCenterlineNew";

--- a/app/process/bikelanes/bikelanesCenterline.sql
+++ b/app/process/bikelanes/bikelanesCenterline.sql
@@ -4,22 +4,14 @@
 -- because negative offsets reverse the order and we want the right side to be aligned we reverse the order again
 -- additionally we check wether the geometry is `simple` because otherwise we might get a MLString
 -- TODO: check parameters `quad_segs` and  `join`
--- INSERT INTO "bikelanes" SELECt osm_type, osm_id, tags,
---   ST_Reverse(
---     ST_Transform(
---       ST_OffsetCurve(
---           ST_Transform(geom, 25833), "offset", 'quad_segs=4 join=round'), 3857))
---             as geom
---   FROM "bikelanes_toTranslate"
---   WHERE ST_IsSimple(geom);
-
 UPDATE "bikelanesCenterlineNew"
   SET geom=ST_Reverse(ST_Transform(ST_OffsetCurve(ST_Transform(geom, 25833), "offset", 'quad_segs=4 join=round'), 3857))
-  WHERE ST_IsSimple(geom) and not ST_IsClosed(geom);
+  WHERE ST_IsSimple(geom) and not ST_IsClosed(geom) and "offset"!=0;
+
+INSERT INTO "bikelanesNew"
+  SELECT osm_type, osm_id, tags, geom
+  FROM "bikelanesCenterlineNew";
 
 -- Query below shows the geometries that would result in MultiLineString
 -- SELECT * from "bikelanesCenterline" WHERE not ST_IsSimple(geom) or ST_IsClosed(geom);
 
--- INSERT INTO "bikelanes"
---   SELECT osm_type, osm_id, tags, geom
---   FROM "bikelanesCenterline";

--- a/app/process/bikelanes/bikelanesNew.lua
+++ b/app/process/bikelanes/bikelanesNew.lua
@@ -175,7 +175,7 @@ function osm2pgsql.process_way(object)
   }
   local projections = { footwayProjection, cyclewayProjection }
 
-  local projDirections = {
+  local projSides = {
     [":right"] = { -1 },
     [":left"] = { 1 },
     [":both"] = { -1, 1 },
@@ -187,8 +187,8 @@ function osm2pgsql.process_way(object)
     -- e.g. a street with bike lane should have offset=streetWidth/2 - bikelaneWidth/2
     -- where a sidewalk with bicycle=yes should have offset=streetWidth/2 + bikelaneWidth/2
     local offset = roadWidth(object.tags) / 2
-    for dir, signs in pairs(projDirections) do
-      local prefixedDir = projection.prefix .. dir
+    for side, signs in pairs(projSides) do
+      local prefixedDir = projection.prefix .. side
       if object.tags[prefixedDir] ~= "no" and object.tags[prefixedDir] ~="separate" then
         local cycleway = projectTags(object.tags, prefixedDir)
         cycleway["highway"] = projection.highway
@@ -198,7 +198,7 @@ function osm2pgsql.process_way(object)
           for key, val in pairs(Metadata(object)) do cycleway[key]=val end
           cycleway["osm_url"] = OsmUrl('way', object)
           for _, sign in pairs(signs) do
-            if not (dir == "" and sign > 0 and object.tags['oneway'] == 'yes') then -- skips implicit case
+            if not (side == "" and sign > 0 and object.tags['oneway'] == 'yes') then -- skips implicit case
               translateTable:insert({
                 tags = normalizeTags(cycleway),
                 geom = object:as_linestring(),

--- a/app/process/bikelanes/bikelanesNew.lua
+++ b/app/process/bikelanes/bikelanesNew.lua
@@ -183,7 +183,9 @@ function osm2pgsql.process_way(object)
   }
 
   for _, projection in pairs(projections) do
-    -- NOTE: the category/projection could also influence the offset e.g. a street with bike lane should have less offset than a sidewalk with bicycle=yes approx. the width of the bike lane itself
+    -- NOTE: the category/projection could also influence the offset
+    -- e.g. a street with bike lane should have offset=streetWidth/2 - bikelaneWidth/2
+    -- where a sidewalk with bicycle=yes should have offset=streetWidth/2 + bikelaneWidth/2
     local offset = roadWidth(object.tags) / 2
     for dir, signs in pairs(projDirections) do
       local prefixedDir = projection.prefix .. dir

--- a/app/process/bikelanes/bikelanesNew.lua
+++ b/app/process/bikelanes/bikelanesNew.lua
@@ -191,7 +191,7 @@ function osm2pgsql.process_way(object)
     local offset = roadWidth(object.tags) / 2
     for dir, signs in pairs(projDirections) do
       local tag = projection.tag .. dir
-      if object.tags[tag] ~= nil and object.tags[tag] ~= "no" then
+      if object.tags[tag] ~= "no" then
         local cycleway = projectTags(object.tags, tag)
         cycleway["highway"] = projection.highway
         cycleway[projection.tag] = object.tags[tag]

--- a/app/process/bikelanes/bikelanesNew.lua
+++ b/app/process/bikelanes/bikelanesNew.lua
@@ -191,15 +191,14 @@ function osm2pgsql.process_way(object)
     local offset = roadWidth(object.tags) / 2
     for dir, signs in pairs(projDirections) do
       local tag = projection.tag .. dir
-      if object.tags[tag] ~= "no" then
+      if object.tags[tag] ~= "no" and object.tags[tag] ~="separate" then
         local cycleway = projectTags(object.tags, tag)
         cycleway["highway"] = projection.highway
         cycleway[projection.tag] = object.tags[tag]
         if BikelaneCategory(cycleway) then
           cycleway._centerline = "generated from centerline with tag=" .. tag
-          for key, val in pairs(object.tags) do
-            if cycleway[key] == nil then cycleway[key]=val end
-          end
+          for key, val in pairs(Metadata(object)) do cycleway[key]=val end
+          cycleway["osm_url"] = OsmUrl('way', object)
           for _, sign in pairs(signs) do
             translateTable:insert({
               tags = normalizeTags(cycleway),

--- a/app/process/bikelanes/bikelanesNew.lua
+++ b/app/process/bikelanes/bikelanesNew.lua
@@ -368,8 +368,10 @@ function osm2pgsql.process_way(object)
           for _, sign in pairs(signs) do
             object.tags._skipNotes = nil
             object.tags.category = cycleway.category
+            local id = object.id .. ({[-1]="_left", [1]="_right"})[sign]
             normalizeTags(object)
             translateTable:insert({
+              osm_id = id,
               tags = object.tags,
               geom = object:as_linestring(),
               offset = sign * offset

--- a/app/process/bikelanes/bikelanesNew.lua
+++ b/app/process/bikelanes/bikelanesNew.lua
@@ -179,11 +179,11 @@ function osm2pgsql.process_way(object)
     [":right"] = { -1 },
     [":left"] = { 1 },
     [":both"] = { -1, 1 },
-    [""] = { -1, 1 } -- TODO: if oneway=yes only apply to the right=-1
+    [""] = { -1, 1 }
   }
 
   for _, projection in pairs(projections) do
-    -- NOTE: the category/projection could also influence the offset
+    -- NOTE: the category/projection should also influence the offset
     -- e.g. a street with bike lane should have offset=streetWidth/2 - bikelaneWidth/2
     -- where a sidewalk with bicycle=yes should have offset=streetWidth/2 + bikelaneWidth/2
     local offset = roadWidth(object.tags) / 2
@@ -193,12 +193,13 @@ function osm2pgsql.process_way(object)
         local cycleway = projectTags(object.tags, prefixedDir)
         cycleway["highway"] = projection.highway
         cycleway[projection.prefix] = object.tags[prefixedDir]
+        -- TODO: maybe copy some unnested tags as fallback. e.g. the surface of an on street bike lane is usally identically to the suface of the street
         if BikelaneCategory(cycleway) then
           cycleway._centerline = "projected tag=" .. prefixedDir
           for key, val in pairs(Metadata(object)) do cycleway[key]=val end
           cycleway["osm_url"] = OsmUrl('way', object)
           for _, sign in pairs(signs) do
-            if not (side == "" and sign > 0 and object.tags['oneway'] == 'yes') then -- skips implicit case
+            if not (side == "" and sign > 0 and object.tags['oneway'] == 'yes') then -- skips implicit case for oneways
               translateTable:insert({
                 tags = normalizeTags(cycleway),
                 geom = object:as_linestring(),

--- a/app/process/bikelanes/bikelanesNew.lua
+++ b/app/process/bikelanes/bikelanesNew.lua
@@ -1,4 +1,5 @@
 package.path = package.path .. ";/app/process/helper/?.lua;/app/process/shared/?.lua"
+package.path = package.path .. ";/app/process/bikelanes/?.lua"
 require("Set")
 require("FilterTags")
 require("ToNumber")
@@ -12,6 +13,7 @@ require("AddSkipInfoToHighways")
 require("AddSkipInfoByWidth")
 require("CheckDataWithinYears")
 require("StartsWith")
+require("categories")
 
 local table = osm2pgsql.define_table({
   name = 'bikelanesNew',
@@ -31,7 +33,6 @@ local skipTable = osm2pgsql.define_table({
   }
 })
 
-
 local translateTable = osm2pgsql.define_table({
   name = 'bikelanesCenterlineNew',
   ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
@@ -41,168 +42,6 @@ local translateTable = osm2pgsql.define_table({
     { column = 'offset', type = 'real' }
   }
 })
-
-local function roadWidth(tags)
-  -- if tags["width"] ~= nil then
-  --   return tonumber(string.gmatch(tags["width"], "[^%s;]+")())
-  -- end
-  -- if tags["est_width"] ~= nil then
-  --   return tonumber(string.gmatch(tags["est_width"], "[^%s;]+")())
-  -- end
-  -- local streetWidths = {primary=10, secondary=8, tertiary=6, residential=6}
-  -- if streetWidths[tags["highway"]] ~= nil then
-  --   return streetWidths[tags["highway"]]
-  -- end
-  return 8
-end
-
--- PREDICATES FOR EACH CATEGORY:
-
--- Handle `highway=pedestrian + bicycle=yes/!=yes`
--- Include "Fußgängerzonen" only when explicitly allowed for bikes. "dismount" does counts as "no"
--- https://wiki.openstreetmap.org/wiki/DE:Tag:highway%3Dpedestrian
-local function pedestiranArea(tags)
-  local results = tags.highway == "pedestrian" and tags.bicycle == "yes"
-  if result then
-    tags.category = "pedestrianArea_bicycleYes"
-  end
-  return results
-end
-
--- Handle `highway=living_street`
--- DE: Verkehrsberuhigter Bereich AKA "Spielstraße"
--- https://wiki.openstreetmap.org/wiki/DE:Tag:highway%3Dliving_street
-local function livingStreet(tags)
-  local result = tags.highway == "living_street" and not tags.bicycle == "no"
-  if result then
-    tags.category = "livingStreet"
-  end
-  return result
-end
-
--- Handle `bicycle_road=yes` and traffic_sign
--- https://wiki.openstreetmap.org/wiki/DE:Key:bicycle%20road
--- tag: "bicycleRoad"
-local function bicycleRoad(tags)
-  local result = tags.bicycle_road == "yes" or StartsWith(tags.traffic_sign, "DE:244")
-  if result then
-    tags.category = "bicycleRoad"
-  end
-  return result
-end
-
--- Handle "Gemeinsamer Geh- und Radweg" based on tagging OR traffic_sign
--- traffic_sign=DE:240, https://wiki.openstreetmap.org/wiki/DE:Tag:traffic_sign%3DDE:240
-local function footAndCycleway(tags)
-  local result = tags.bicycle == "designated" and tags.foot == "designated" and tags.segregated == "no"
-  result = result or StartsWith(tags.traffic_sign, "DE:240")
-  if result then
-    tags.category = "footAndCycleway_shared"
-  end
-  return result
-end
-
--- Handle "Getrennter Geh- und Radweg" (and Rad- und Gehweg) based on tagging OR traffic_sign
--- traffic_sign=DE:241-30, https://wiki.openstreetmap.org/wiki/DE:Tag:traffic_sign%3DDE:241-30
--- traffic_sign=DE:241-31, https://wiki.openstreetmap.org/wiki/DE:Tag:traffic_sign%3DDE:241-31
-local function footAndCyclewaySegregated(tags)
-  local result = tags.bicycle == "designated" and tags.foot == "designated" and tags.segregated == "yes"
-  result = result or StartsWith(tags.traffic_sign, "DE:241")
-  if result then
-    tags.category = "footAndCycleway_segregated"
-  end
-  return result
-end
-
--- Handle "Gehweg, Fahrrad frei"
--- traffic_sign=DE:239,1022-10, https://wiki.openstreetmap.org/wiki/DE:Tag:traffic_sign%3DDE:239
-local function footwayBicycleAllowed(tags)
-  local result = tags.highway == "footway" or tags.highway == "path"
-  -- Note: We might be missing some traffic_sign that have mulibe secondary signs like "DE:239,123,1022-10". That's OK for now…
-  -- Note: For ZES we explicity checked that the traffic_sign is not on a highway=cycleway; we do the same here but differently
-  result = result and
-      (tags.bicycle == "yes" or StartsWith(tags.traffic_sign, "DE:239,1022-10") or tags.traffic_sign == 'DE:1022-10')
-  -- The access based tagging would include free running path through woods like https://www.openstreetmap.org/way/23366687
-  -- We filter those based on mtb:scale=*.
-  result = result and not tags["mtb:scale"]
-  if result then
-    tags.category = "footway_bicycleYes"
-  end
-  return result
-end
-
--- Handle "baulich abgesetzte Radwege" ("Protected Bike Lane")
--- This part relies heavly on the `is_sidepath` tagging.
-local function cyclewaySeparated(tags)
-  -- Case: Separate cycleway next to a road
-  --    Eg https://www.openstreetmap.org/way/278057274
-  local result = (tags.highway == "cycleway" and tags.is_sidepath == "yes")
-  -- Case: The crossing version of a separate cycleway next to a road
-  -- The same case as the is_sidepath=yes above, but on crossings we don't set that.
-  --    Eg https://www.openstreetmap.org/way/963592923
-  result = result or (tags.highway == "cycleway" and tags.cycleway == "crossing")
-  -- Case: Separate cycleway identified via traffic_sign
-  -- traffic_sign=DE:237, https://wiki.openstreetmap.org/wiki/DE:Tag:traffic%20sign=DE:237
-  --    Eg https://www.openstreetmap.org/way/964476026
-  -- Note: We do not check cycleway=lane (eg https://www.openstreetmap.org/way/761086733)
-  --    since we consider this a separate cycleway.
-  result = result or (tags.traffic_sign == "DE:237" and tags.is_sidepath == "yes")
-  -- Case: Separate cycleway identified via "track"-tagging.
-  --    https://wiki.openstreetmap.org/wiki/DE:Tag:cycleway%3Dtrack
-  --    https://wiki.openstreetmap.org/wiki/DE:Tag:cycleway%3Dopposite_track
-  result = result or (tags.cycleway == "track" or tags.cycleway == "opposite_track")
-
-  if result then
-    tags.category = "cyclewaySeparated"
-  end
-  return result
-end
-
-local function cyclewayOnHighway(tags)
-  -- Case: Cycleway identified via "lane"-tagging, which means it is part of the highway.
-  --    TBD: We might need to split of the cycleway=lane
-  --    https://wiki.openstreetmap.org/wiki/DE:Tag:cycleway%3Dlane
-  --    https://wiki.openstreetmap.org/wiki/DE:Tag:cycleway%3Dopposite_lane
-  local result = tags.cycleway == "lane" or tags.cycleway == "opposite_lane"
-
-  if result then
-    tags.category = "cyclewayOnHighway"
-  end
-  return result
-end
-
--- deprecated only for backwards compatibility
-local function oldCenterline(tags)
-  if tags["sidewalk:left:bicycle"] == "yes" or tags["sidewalk:right:bicycle"] == "yes" or tags["sidewalk:both:bicycle"] then
-    tags._centerline = "tagged on centerline"
-    tags.category = "footway_bicycleYes"
-    return true
-  end
-  if tags["cycleway:right"] == "track" or tags["cycleway:left"] == "track" or tags["cycleway:both"] == "track" then
-    tags.category = "cyclewaySeparated"
-    tags._centerline = "tagged on centerline"
-    return true
-  end
-  if tags["cycleway:right"] == "lane" or tags["cycleway:left"] == "lane" or tags["cycleway:both"] == "lane" then
-    tags.category = "cyclewayOnHighway"
-    tags._centerline = "tagged on centerline"
-    return true
-  end
-  return false
-end
-
--- Handle "frei geführte Radwege", dedicated cycleways that are not next to a road
--- Eg. https://www.openstreetmap.org/way/27701956
--- traffic_sign=DE:237, https://wiki.openstreetmap.org/wiki/DE:Tag:traffic%20sign=DE:237
--- tag: "cyclewayAlone"
-local function cycleWayAlone(tags)
-  local result = tags.highway == "cycleway" and tags.traffic_sign == "DE:237"
-  result = result and (tags.is_sidepath == nil or tags.is_sidepath == "no")
-  if result then
-    tags.category = "cyclewayAlone"
-  end
-  return result
-end
 
 -- whitelist of tags we want to insert intro the DB
 local allowed_tags = Set({
@@ -238,17 +77,44 @@ local allowed_tags = Set({
   "traffic_sign",
 })
 
-local predicates = { pedestiranArea, livingStreet, bicycleRoad, footAndCycleway, footAndCyclewaySegregated,
-  footwayBicycleAllowed, cyclewaySeparated, cyclewayOnHighway, cycleWayAlone }
 
-local function applyPredicates(tags)
-  for _, predicate in pairs(predicates) do
-    if predicate(tags) then
-      return true
-    end
-  end
-  return false
+local footwayProjection = {
+  highway = "footway",
+  dest = "bicycle",
+  tags = {
+    ["sidewalk:left:bicycle"] = { 1 },
+    ["sidewalk:right:bicycle"] = { -1 },
+    ["sidewalk:both:bicycle"] = { -1, 1 },
+    ["sidewalk:bicycle"] = { -1, 1 },
+  },
+}
+
+local cyclewayProjection = {
+  highway = "cycleway",
+  dest = "cycleway",
+  tags = {
+    ["cycleway:left"] = { 1 },
+    ["cycleway:right"] = { -1 },
+    ["cycleway:both"] = { -1, 1 },
+    ["cycleway"] = { -1, 1 },
+  },
+}
+
+local function roadWidth(tags)
+  -- if tags["width"] ~= nil then
+  --   return tonumber(string.gmatch(tags["width"], "[^%s;]+")())
+  -- end
+  -- if tags["est_width"] ~= nil then
+  --   return tonumber(string.gmatch(tags["est_width"], "[^%s;]+")())
+  -- end
+  -- local streetWidths = {primary=10, secondary=8, tertiary=6, residential=6}
+  -- if streetWidths[tags["highway"]] ~= nil then
+  --   return streetWidths[tags["highway"]]
+  -- end
+  return 8
 end
+
+
 
 local function normalizeTags(object)
   FilterTags(object.tags, allowed_tags)
@@ -304,7 +170,7 @@ function osm2pgsql.process_way(object)
 
 
   -- apply predicates
-  if applyPredicates(object.tags) then
+  if BikelaneCategory(object.tags) then
     object.tags._skipNotes = nil
     normalizeTags(object)
     table:insert({
@@ -320,41 +186,20 @@ function osm2pgsql.process_way(object)
     return
   end
 
-  -- this is only to stay consistent with the previous version
-  if oldCenterline(object.tags) then
-    object.tags._skipNotes = nil
-    normalizeTags(object)
-    table:insert({
-      tags = object.tags,
-      geom = object:as_linestring()
-    })
-  end
+  -- -- this is only to stay consistent with the previous version
+  -- if OldCenterline(object.tags) then
+  --   object.tags._skipNotes = nil
+  --   normalizeTags(object)
+  --   table:insert({
+  --     tags = object.tags,
+  --     geom = object:as_linestring()
+  --   })
+  -- end
 
   -- apply predicates nested
-  -- transformations:
-  local footwayTransformer = {
-    highway = "footway",
-    dest = "bicycle",
-    tags = {
-      ["sidewalk:left:bicycle"] = { 1 },
-      ["sidewalk:right:bicycle"] = { -1 },
-      ["sidewalk:both:bicycle"] = { -1, 1 },
-      ["sidewalk:bicycle"] = { -1, 1 },
-    },
-  }
-  local cyclewayTransformer = {
-    highway = "cycleway",
-    dest = "cycleway",
-    tags = {
-      ["cycleway:left"] = { 1 },
-      ["cycleway:right"] = { -1 },
-      ["cycleway:both"] = { -1, 1 },
-      ["cycleway"] = { -1, 1 },
-    },
-  }
-  local transformations = { footwayTransformer, cyclewayTransformer }
+  local projections = { footwayProjection, cyclewayProjection }
 
-  for _, transformer in pairs(transformations) do
+  for _, transformer in pairs(projections) do
     -- set the highway category
     local cycleway = { highway = transformer.highway }
     -- NOTE: the category/transformer should also influence the offset e.g. a street with bike lane should have less offset than a sidewalk with bicycle=yes approx. the width of the bike lane itself
@@ -363,7 +208,7 @@ function osm2pgsql.process_way(object)
       if object.tags[tag] ~= nil and object.tags[tag] ~= "no" then
         -- sets the bicycle tag to the value of nested tags
         cycleway[transformer.dest] = object.tags[tag]
-        if applyPredicates(cycleway) then
+        if BikelaneCategory(cycleway) then
           object.tags._centerline = "tagged on centerline"
           for _, sign in pairs(signs) do
             object.tags._skipNotes = nil

--- a/app/process/bikelanes/bikelanesNew.lua
+++ b/app/process/bikelanes/bikelanesNew.lua
@@ -197,8 +197,10 @@ function osm2pgsql.process_way(object)
         cycleway[projection.tag] = object.tags[tag]
         if BikelaneCategory(cycleway) then
           cycleway._centerline = "generated from centerline with tag=" .. tag
+          for key, val in pairs(object.tags) do
+            if cycleway[key] == nil then cycleway[key]=val end
+          end
           for _, sign in pairs(signs) do
-            -- TODO: insert tags from object.tags -> cycleway (prefer cycleway in case if ambiguity)
             translateTable:insert({
               tags = normalizeTags(cycleway),
               geom = object:as_linestring(),

--- a/app/process/bikelanes/bikelanesNew.lua
+++ b/app/process/bikelanes/bikelanesNew.lua
@@ -135,11 +135,11 @@ end
 -- projects all tags prefix:subtag=val -> subtag=val
 local function projectTags(tags, prefix)
   local projectedTags = {}
-  for key,val  in pairs(tags) do
-    if key ~= prefix and StartsWith(key, prefix) then
+  for prefixedKey,val  in pairs(tags) do
+    if prefixedKey ~= prefix and StartsWith(prefixedKey, prefix) then
       -- offset of 2 due to 1-indexing and for removing the ':'
-      local key_suffix = string.sub(key, string.len(prefix) + 2)
-      projectedTags[key_suffix] = val
+      local key = string.sub(prefixedKey, string.len(prefix) + 2)
+      projectedTags[key] = val
     end
   end
   return projectedTags

--- a/app/process/bikelanes/bikelanesNew.lua
+++ b/app/process/bikelanes/bikelanesNew.lua
@@ -148,7 +148,8 @@ function osm2pgsql.process_way(object)
   AddMetadata(object);
   AddUrl("way", object)
 
-  AddSkipInfoToHighways(object)  if object.tags._skip == true then
+  AddSkipInfoToHighways(object)
+  if object.tags._skip == true then
     intoSkipList(object)
     return
   end
@@ -164,7 +165,6 @@ function osm2pgsql.process_way(object)
   end
 
   -- apply predicates nested
-
   local footwayProjection = {
     highway = "footway",
     prefix = 'sidewalk'
@@ -196,11 +196,13 @@ function osm2pgsql.process_way(object)
           for key, val in pairs(Metadata(object)) do cycleway[key]=val end
           cycleway["osm_url"] = OsmUrl('way', object)
           for _, sign in pairs(signs) do
-            translateTable:insert({
-              tags = normalizeTags(cycleway),
-              geom = object:as_linestring(),
-              offset = sign * offset
-            })
+            if not (dir == "" and sign > 0 and object.tags['oneway'] == 'yes') then -- skips implicit case
+              translateTable:insert({
+                tags = normalizeTags(cycleway),
+                geom = object:as_linestring(),
+                offset = sign * offset
+              })
+            end
           end
         end
       end

--- a/app/process/bikelanes/categories.lua
+++ b/app/process/bikelanes/categories.lua
@@ -1,0 +1,139 @@
+
+-- PREDICATES FOR EACH CATEGORY:
+
+-- Handle `highway=pedestrian + bicycle=yes/!=yes`
+-- Include "Fußgängerzonen" only when explicitly allowed for bikes. "dismount" does counts as "no"
+-- https://wiki.openstreetmap.org/wiki/DE:Tag:highway%3Dpedestrian
+local function pedestiranArea(tags)
+  local results = tags.highway == "pedestrian" and tags.bicycle == "yes"
+  if result then
+    tags.category = "pedestrianArea_bicycleYes"
+  end
+  return results
+end
+
+-- Handle `highway=living_street`
+-- DE: Verkehrsberuhigter Bereich AKA "Spielstraße"
+-- https://wiki.openstreetmap.org/wiki/DE:Tag:highway%3Dliving_street
+local function livingStreet(tags)
+  local result = tags.highway == "living_street" and not tags.bicycle == "no"
+  if result then
+    tags.category = "livingStreet"
+  end
+  return result
+end
+
+-- Handle `bicycle_road=yes` and traffic_sign
+-- https://wiki.openstreetmap.org/wiki/DE:Key:bicycle%20road
+-- tag: "bicycleRoad"
+local function bicycleRoad(tags)
+  local result = tags.bicycle_road == "yes" or StartsWith(tags.traffic_sign, "DE:244")
+  if result then
+    tags.category = "bicycleRoad"
+  end
+  return result
+end
+
+-- Handle "Gemeinsamer Geh- und Radweg" based on tagging OR traffic_sign
+-- traffic_sign=DE:240, https://wiki.openstreetmap.org/wiki/DE:Tag:traffic_sign%3DDE:240
+local function footAndCycleway(tags)
+  local result = tags.bicycle == "designated" and tags.foot == "designated" and tags.segregated == "no"
+  result = result or StartsWith(tags.traffic_sign, "DE:240")
+  if result then
+    tags.category = "footAndCycleway_shared"
+  end
+  return result
+end
+
+-- Handle "Getrennter Geh- und Radweg" (and Rad- und Gehweg) based on tagging OR traffic_sign
+-- traffic_sign=DE:241-30, https://wiki.openstreetmap.org/wiki/DE:Tag:traffic_sign%3DDE:241-30
+-- traffic_sign=DE:241-31, https://wiki.openstreetmap.org/wiki/DE:Tag:traffic_sign%3DDE:241-31
+local function footAndCyclewaySegregated(tags)
+  local result = tags.bicycle == "designated" and tags.foot == "designated" and tags.segregated == "yes"
+  result = result or StartsWith(tags.traffic_sign, "DE:241")
+  if result then
+    tags.category = "footAndCycleway_segregated"
+  end
+  return result
+end
+
+-- Handle "Gehweg, Fahrrad frei"
+-- traffic_sign=DE:239,1022-10, https://wiki.openstreetmap.org/wiki/DE:Tag:traffic_sign%3DDE:239
+local function footwayBicycleAllowed(tags)
+  local result = tags.highway == "footway" or tags.highway == "path"
+  -- Note: We might be missing some traffic_sign that have mulibe secondary signs like "DE:239,123,1022-10". That's OK for now…
+  -- Note: For ZES we explicity checked that the traffic_sign is not on a highway=cycleway; we do the same here but differently
+  result = result and
+      (tags.bicycle == "yes" or StartsWith(tags.traffic_sign, "DE:239,1022-10") or tags.traffic_sign == 'DE:1022-10')
+  -- The access based tagging would include free running path through woods like https://www.openstreetmap.org/way/23366687
+  -- We filter those based on mtb:scale=*.
+  result = result and not tags["mtb:scale"]
+  if result then
+    tags.category = "footway_bicycleYes"
+  end
+  return result
+end
+
+-- Handle "baulich abgesetzte Radwege" ("Protected Bike Lane")
+-- This part relies heavly on the `is_sidepath` tagging.
+local function cyclewaySeparated(tags)
+  -- Case: Separate cycleway next to a road
+  --    Eg https://www.openstreetmap.org/way/278057274
+  local result = (tags.highway == "cycleway" and tags.is_sidepath == "yes")
+  -- Case: The crossing version of a separate cycleway next to a road
+  -- The same case as the is_sidepath=yes above, but on crossings we don't set that.
+  --    Eg https://www.openstreetmap.org/way/963592923
+  result = result or (tags.highway == "cycleway" and tags.cycleway == "crossing")
+  -- Case: Separate cycleway identified via traffic_sign
+  -- traffic_sign=DE:237, https://wiki.openstreetmap.org/wiki/DE:Tag:traffic%20sign=DE:237
+  --    Eg https://www.openstreetmap.org/way/964476026
+  -- Note: We do not check cycleway=lane (eg https://www.openstreetmap.org/way/761086733)
+  --    since we consider this a separate cycleway.
+  result = result or (tags.traffic_sign == "DE:237" and tags.is_sidepath == "yes")
+  -- Case: Separate cycleway identified via "track"-tagging.
+  --    https://wiki.openstreetmap.org/wiki/DE:Tag:cycleway%3Dtrack
+  --    https://wiki.openstreetmap.org/wiki/DE:Tag:cycleway%3Dopposite_track
+  result = result or (tags.cycleway == "track" or tags.cycleway == "opposite_track")
+
+  if result then
+    tags.category = "cyclewaySeparated"
+  end
+  return result
+end
+
+local function cyclewayOnHighway(tags)
+  -- Case: Cycleway identified via "lane"-tagging, which means it is part of the highway.
+  --    TBD: We might need to split of the cycleway=lane
+  --    https://wiki.openstreetmap.org/wiki/DE:Tag:cycleway%3Dlane
+  --    https://wiki.openstreetmap.org/wiki/DE:Tag:cycleway%3Dopposite_lane
+  local result = tags.cycleway == "lane" or tags.cycleway == "opposite_lane"
+
+  if result then
+    tags.category = "cyclewayOnHighway"
+  end
+  return result
+end
+
+-- Handle "frei geführte Radwege", dedicated cycleways that are not next to a road
+-- Eg. https://www.openstreetmap.org/way/27701956
+-- traffic_sign=DE:237, https://wiki.openstreetmap.org/wiki/DE:Tag:traffic%20sign=DE:237
+-- tag: "cyclewayAlone"
+local function cycleWayAlone(tags)
+  local result = tags.highway == "cycleway" and tags.traffic_sign == "DE:237"
+  result = result and (tags.is_sidepath == nil or tags.is_sidepath == "no")
+  if result then
+    tags.category = "cyclewayAlone"
+  end
+  return result
+end
+
+function BikelaneCategory(tags)
+  local categories = { pedestiranArea, livingStreet, bicycleRoad, footAndCycleway, footAndCyclewaySegregated,
+  footwayBicycleAllowed, cyclewaySeparated, cyclewayOnHighway, cycleWayAlone }
+  for _, predicate in pairs(categories) do
+    if predicate(tags) then
+      return true
+    end
+  end
+  return false
+end

--- a/app/process/helper/AddMetadata.lua
+++ b/app/process/helper/AddMetadata.lua
@@ -10,3 +10,19 @@ function AddMetadata(object)
   object.tags.updated_by = object.user
   object.tags.version = object.version
 end
+
+function Metadata(object)
+  -- We use the tags-"object" to make the timestamp accessible.
+  -- The osm2pgsql examples use store the timestamp as a separate column. But…
+  --    - …I could not get this working
+  --    - …and I don't see the benefit. Maybe it is needed to efficintly filter the table for incremental updates?
+  -- Docs: https://github.com/openstreetmap/osm2pgsql/blob/master/flex-config/attributes.lua#L18-L21
+  --    But maybe also https://github.com/openstreetmap/osm2pgsql/blob/master/flex-config/unitable.lua#L63-L66 ?
+  local meta = {
+    ["update_at"] = os.date('!%Y-%m-%dT%H:%M:%SZ', object.timestamp),
+    ["updated_by"] = object.user,  -- 'user' not present in regular osm file
+    ["version"] = object.version,
+  }
+  return meta
+end
+

--- a/app/process/helper/AddUrl.lua
+++ b/app/process/helper/AddUrl.lua
@@ -1,4 +1,8 @@
 -- * @param `osm_type` can be 'way', 'node', 'relation' (valid osm.org URL parts)
+function OsmUrl(osm_type, object)
+  return "https://osm.org/" .. osm_type .. "/" .. object.id
+end
+
 function AddUrl(osm_type, object)
-  object.tags.osm_url = "https://osm.org/" .. osm_type .. "/" .. object.id
+  object.tags.osm_url = OsmUrl(osm_type, object)
 end

--- a/app/process/helper/FilterTags.lua
+++ b/app/process/helper/FilterTags.lua
@@ -7,3 +7,14 @@ function FilterTags(tagsObject, allowedTags)
     end
   end
 end
+
+function FilterTags2(tags, allowedTags)
+  local tagsFiltered = {}
+  for key, _ in pairs(allowedTags) do
+    if tags[key] ~= nil then
+      tagsFiltered[key] = tags[key]
+    end
+  end
+  return tagsFiltered
+end
+


### PR DESCRIPTION
This PR changes the way the center line projections work in the following way:
 - projections are a pair of `highway` and `prefix` (strings)
 - for every possible 'side= :left | :right | :both | "" (implicit both)`  a new object with `highway=highway` and all tags of the original object which have `prefix:side` is created
 - the new object gets skipped if the original object has `prefix:direction=no` or `prefix:side=separate`
 - center line object get a signed `id` e.g. a way that is transformed to the right with `offset=-x` get the `id=-osm_id `

This has two benefits:
 - the projection logic is simpler and more generic (directions don't need to be defined explicitly per projection)
 - all nested tags from the original object appear flatted in the new one
 - we can treat the implicit case where `side=""` and `oneway=yes`

Through this procedure we gain 11 ways in the category `footAndCycleway_shared`:
 - https://osm.org/way/400258971
 - https://osm.org/way/973098905
 - https://osm.org/way/411704317
 - https://osm.org/way/400258976
 - https://osm.org/way/743250295
 - https://osm.org/way/24960980
 - https://osm.org/way/639510777
 - https://osm.org/way/639616143
 - https://osm.org/way/422958887
 - https://osm.org/way/647477763
 - https://osm.org/way/110514011
 - https://osm.org/way/724615542

But at the same time also loose the following 3 ways from the category `footway_bicycleYes`:
 - https://osm.org/way/310306834
 - https://osm.org/way/43128530
 - https://osm.org/way/382269754

 all due to the `sidewalk:side=separate` tag.
 

